### PR TITLE
[Mellanox] Fixed sai xml name format bug

### DIFF
--- a/platform/mellanox/cmis_host_mgmt/cmis_host_mgmt.py
+++ b/platform/mellanox/cmis_host_mgmt/cmis_host_mgmt.py
@@ -61,7 +61,7 @@ class CMISHostMgmtActivator:
                         if param == "sai_profile" and not re.search(CMISHostMgmtActivator.PARAMS[param]["disabled_param"], lines):
                             if not re.search(CMISHostMgmtActivator.PARAMS[param]["enabled_param"], lines): 
                                 with open(file_path, 'a') as param_file:
-                                    param_file.write(CMISHostMgmtActivator.PARAMS[param]["enabled_param"])
+                                    param_file.write(CMISHostMgmtActivator.PARAMS[param]["enabled_param"] + '\n')
                                 return
 
                         lines = re.sub(CMISHostMgmtActivator.PARAMS[param]["disabled_param"],

--- a/platform/mellanox/cmis_host_mgmt/cmis_host_mgmt.py
+++ b/platform/mellanox/cmis_host_mgmt/cmis_host_mgmt.py
@@ -22,6 +22,7 @@ import re
 import os
 import subprocess
 import glob
+from pathlib import Path
 
 
 class CMISHostMgmtActivator:
@@ -139,11 +140,15 @@ class CMISHostMgmtActivator:
         if not CMISHostMgmtActivator.is_spc_supported(sku_num):
             print("Error: unsupported platform - feature is supported on SPC3 and higher.")
 
-        # Find sai_*.xml, assume there can only be one in the directory
-        sai_xml_list = glob.glob(os.path.join(sku_path + "/sai*.xml"))
-        sai_xml_name = sai_xml_list[0]
-        if sai_xml_name:
-            sai_xml_name = sai_xml_name.split('/')[-1]
+        sai_profile_file = '{}/{}'.format(sku_path, CMISHostMgmtActivator.PARAMS["sai_profile"]["file_name"])
+        lines = None
+        with open(sai_profile_file, 'r') as saiprofile:
+            lines = saiprofile.read()
+        
+        sai_xml_path = re.search("SAI_INIT_CONFIG_FILE.*", lines).group()
+
+        if sai_xml_path:
+            sai_xml_name = Path(sai_xml_path).name
             CMISHostMgmtActivator.PARAMS["sai_xml"]["file_name"] = sai_xml_name
         else:
             print("Error: no sai_*.xml file present")

--- a/platform/mellanox/cmis_host_mgmt/cmis_host_mgmt.py
+++ b/platform/mellanox/cmis_host_mgmt/cmis_host_mgmt.py
@@ -21,6 +21,7 @@ import click
 import re
 import os
 import subprocess
+import glob
 
 
 class CMISHostMgmtActivator:
@@ -137,8 +138,15 @@ class CMISHostMgmtActivator:
 
         if not CMISHostMgmtActivator.is_spc_supported(sku_num):
             print("Error: unsupported platform - feature is supported on SPC3 and higher.")
-            
-        CMISHostMgmtActivator.PARAMS["sai_xml"]["file_name"] = "sai_{0}.xml".format(sku_num)
+
+        # Find sai_*.xml, assume there can only be one in the directory
+        sai_xml_list = glob.glob(os.path.join(sku_path + "/sai*.xml"))
+        sai_xml_name = sai_xml_list[0]
+        if sai_xml_name:
+            sai_xml_name = sai_xml_name.split('/')[-1]
+            CMISHostMgmtActivator.PARAMS["sai_xml"]["file_name"] = sai_xml_name
+        else:
+            print("Error: no sai_*.xml file present")
 
         CMISHostMgmtActivator.copy_file(args[0], sku_path)
         CMISHostMgmtActivator.copy_file(args[1], sku_path)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixed the name that the script looks for when checking sai_*.xml 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Changed regex to look for any file that matches the regex 'sai*.xml'
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

